### PR TITLE
fix(win32): Use join for paths and escape win32 input paths

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -35,7 +35,7 @@ class DevelopmentServer {
 
     constructor(
         customBlockPath = 'custom_block',
-        entryFilePaths = ['src/index.tsx', 'src/settings.ts'],
+        entryFilePaths = [join('src', 'index.tsx'), join('src', 'settings.ts')],
         port = 5600,
         options: CompilerOptions
     ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import minimist from 'minimist';
 import buildOptions from 'minimist-options';
+import { join } from 'path';
 import { exit } from 'process';
 import { createNewProject } from './commands/create';
 import { createDeployment } from './commands/deploy';
@@ -38,7 +39,7 @@ const options = buildOptions({
     [Argument.EntryPath]: {
         type: 'string',
         alias: 'e',
-        default: 'src/index.tsx',
+        default: join('src', 'index.tsx'),
     },
     [Argument.Minify]: {
         type: 'boolean',
@@ -58,7 +59,7 @@ const options = buildOptions({
     [Argument.SettingsPath]: {
         type: 'string',
         alias: 'e',
-        default: 'src/settings.ts',
+        default: join('src', 'settings.ts'),
     },
 });
 const parseArgs = minimist(process.argv.slice(2), options);

--- a/src/utils/compile.ts
+++ b/src/utils/compile.ts
@@ -1,7 +1,7 @@
 import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
-import { join, resolve } from 'path';
+import { join, resolve, sep } from 'path';
 import { OutputOptions, RollupOptions, rollup } from 'rollup';
 import combine from 'rollup-plugin-combine';
 import esbuild from 'rollup-plugin-esbuild';
@@ -56,6 +56,16 @@ export const compile = async (
     }
 };
 
+const getEscapedMultiInputPaths = (projectPath: string, entryFileNames: string[]) =>
+    entryFileNames.map((entryFileName) => {
+        const paths = join(projectPath, entryFileName);
+        if (process.platform === 'win32') {
+            return paths.split(sep).join(`\\${sep}`);
+        }
+
+        return paths;
+    });
+
 const rollupCompile = async (
     projectPath: string,
     entryFileNames: string[],
@@ -65,7 +75,7 @@ const rollupCompile = async (
     const rollupConfig: RollupOptions = {
         external: ['react', 'react-dom'],
         treeshake: options.treeshake,
-        input: entryFileNames.map((entryFileName) => join(projectPath, entryFileName)),
+        input: getEscapedMultiInputPaths(projectPath, entryFileNames),
         plugins: [
             combine({
                 exports: 'named',


### PR DESCRIPTION
https://app.clickup.com/t/1za7nhv

depends on https://github.com/Frontify/frontify-cli/pull/171