### PR TITLE
feat: use new marketplace endpoint

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -90,7 +90,7 @@ export const createDeployment = async (
                 const accessToken = Configuration.get('tokens.access_token');
                 const headers = new Headers({ Authorization: `Bearer ${accessToken}` });
 
-                const response = await httpClient.put(`/api/marketplace-app/apps/${manifest.appId}`, request, {
+                const response = await httpClient.put(`/api/marketplace/app/${manifest.appId}`, request, {
                     headers,
                 });
 

--- a/src/utils/compile.ts
+++ b/src/utils/compile.ts
@@ -123,7 +123,7 @@ const rollupCompile = async (
             'react-dom': 'ReactDOM',
         },
         banner: `
-            const global = window;
+            var global = window;
             window.require = (moduleName) => {
                 switch (moduleName) {
                     case "react":

--- a/src/utils/compile.ts
+++ b/src/utils/compile.ts
@@ -117,6 +117,7 @@ const rollupCompile = async (
         dir: options.distPath,
         format: 'iife',
         name: iifeGlobalName,
+        extend: true,
         globals: {
             react: 'React',
             'react-dom': 'ReactDOM',


### PR DESCRIPTION
- use new marketplace endpoint
- use `extend` to allow uuid as object name ([doc](https://rollupjs.org/guide/en/#outputextend))
- fix issue where 2 blocks `const global` would collide