### PR TITLE
fix: enable hidden files

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -22,7 +22,7 @@ interface Options {
 }
 
 const makeFilesDict = async (glob: string, ignoreGlobs?: string[]) => {
-    const folderFiles = await fastGlob(join(glob, '**'), { ignore: ignoreGlobs });
+    const folderFiles = await fastGlob(join(glob, '**'), { ignore: ignoreGlobs, dot: true });
 
     const folderFilenames = folderFiles.map((filePath) => filePath.replace(`${glob}/`, ''));
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -8,7 +8,6 @@ import { Configuration } from '../utils/configuration';
 import { exit } from 'process';
 import { getValidInstanceUrl } from '../utils/url';
 import { HttpClient } from '../utils/httpClient';
-import { Headers } from 'node-fetch';
 import { getUser } from '../utils/user';
 
 export interface OauthRandomCodeChallenge {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -100,25 +100,15 @@ export class Authenticator {
             throw new Error('Random challenge needs to be defined');
         }
 
-        const headers = new Headers({
-            'Content-Type': 'application/json',
-        });
-
         try {
-            const tokens = await this.httpClient.post<OauthAccessTokenApiResponse>(
-                '/api/oauth/accesstoken',
-                {
-                    grant_type: 'authorization_code',
-                    client_id: 'block-cli',
-                    redirect_uri: 'http://localhost:5600/oauth',
-                    scope: 'basic:read%2Bblocks:read%2Bblocks:write',
-                    code_verifier: this.randomChallenge.secret,
-                    code: authorizationCode,
-                },
-                {
-                    headers,
-                }
-            );
+            const tokens = await this.httpClient.post<OauthAccessTokenApiResponse>('/api/oauth/accesstoken', {
+                grant_type: 'authorization_code',
+                client_id: 'block-cli',
+                redirect_uri: 'http://localhost:5600/oauth',
+                scope: 'basic:read%2Bblocks:read%2Bblocks:write',
+                code_verifier: this.randomChallenge.secret,
+                code: authorizationCode,
+            });
 
             return tokens;
         } catch (error) {


### PR DESCRIPTION
Fix 1: 
Allow hidden files to be uploaded to clarify

Fix 2:
Remove Content-Type header from function, since this is automatically appended by the httpClient if a request body is present.

https://github.com/Frontify/clarify/pull/11275 must be merged first