### PR TITLE
feat: allow external ips to access server

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -6,22 +6,12 @@ import { viteExternalsPlugin } from 'vite-plugin-externals';
 import { Logger } from '../utils/logger';
 import pkg from '../../package.json';
 
-export type Setting = {
-    id: string;
-    label: string;
-    type: string;
-    placeholder?: string;
-    value?: string;
-};
-
 class DevelopmentServer {
-    private readonly entryFilePath: string;
-    private readonly port: number;
-
-    constructor(entryFilePath: string, port: number) {
-        this.entryFilePath = entryFilePath;
-        this.port = port;
-    }
+    constructor(
+        private readonly entryFilePath: string,
+        private readonly port: number,
+        private readonly allowExternal: boolean
+    ) {}
 
     async serve(): Promise<void> {
         try {
@@ -41,16 +31,12 @@ class DevelopmentServer {
                 appType: 'custom',
                 server: {
                     port: this.port,
-                    host: 'localhost',
+                    host: this.allowExternal ? '0.0.0.0' : 'localhost',
                     cors: true,
                     hmr: {
                         port: this.port,
-                        host: 'localhost',
+                        host: this.allowExternal ? '0.0.0.0' : 'localhost',
                         protocol: 'ws',
-                    },
-                    fs: {
-                        // INFO: Allow linked packages `../..`.
-                        strict: false,
                     },
                 },
             });
@@ -91,9 +77,13 @@ class DevelopmentServer {
     }
 }
 
-export const createDevelopmentServer = async (entryFilePath: string, port: number): Promise<void> => {
+export const createDevelopmentServer = async (
+    entryFilePath: string,
+    port: number,
+    allowExternal: boolean
+): Promise<void> => {
     Logger.info('Starting the development server...');
 
-    const developmentServer = new DevelopmentServer(entryFilePath, port);
+    const developmentServer = new DevelopmentServer(entryFilePath, port, allowExternal);
     await developmentServer.serve();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,8 +56,11 @@ for (const appType of ['block', 'theme']) {
         .option('--port <port>', '[number] specify port', {
             default: process.env.PORT || 5600,
         })
+        .option('--allowExternal, --allow-external', '[boolean] allow external IPs to access the server', {
+            default: false,
+        })
         .action(async (options) => {
-            await createDevelopmentServer(options.entryPath, options.port);
+            await createDevelopmentServer(options.entryPath, options.port, options.allowExternal);
         });
 }
 
@@ -69,8 +72,11 @@ cli.command('serve', 'serve the app locally')
     .option('--port <port>', '[number] specify port', {
         default: process.env.PORT || 5600,
     })
+    .option('--allowExternal, --allow-external', '[boolean] allow external IPs to access the server', {
+        default: false,
+    })
     .action(async (options) => {
-        await createDevelopmentServer(options.entryPath, options.port);
+        await createDevelopmentServer(options.entryPath, options.port, options.allowExternal);
     });
 
 /**


### PR DESCRIPTION
- Allow any IPs to access the dev server with `--allowExternal`
- Remove the `fs.strict = false` as [it has been fixed ](https://github.com/vitejs/vite/issues/2820)
- Remove unused type `Settings` as it has been moved to `@frontify/guideline-blocks-settings`